### PR TITLE
Feature add to the base block images + auto publish with GitHub actions

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -1,0 +1,32 @@
+name: Build and publish container to balena
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - master
+      - main
+
+jobs:
+  balena:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        fleet:
+          [
+            hslatman/tailscale-rpi,
+            hslatman/tailscale-armv7hf,
+            hslatman/tailscale-aarch64,
+            hslatman/tailscale-amd64,
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: balena-io/deploy-to-balena-action@v0.9.0
+        with:
+          balena_token: ${{ secrets.BALENA_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          environment: balena-cloud.com
+          fleet: ${{ matrix.fleet }}
+          versionbot: true

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,4 +1,4 @@
-name: Build and publish container
+name: Build and publish container to GitHub
 
 on:
   push:
@@ -6,18 +6,18 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Why ?'
+        description: "Why ?"
         required: false
-        default: ''
+        default: ""
 
 jobs:
-  ghr_push:
+  ghcr:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,46 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Create and publish a Docker image
+name: Build and publish container
 
 on:
   push:
-    branches: ['main']
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why ?'
+        required: false
+        default: ''
 
 jobs:
-  build-and-push-image:
+  ghr_push:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    if: github.event_name == 'push'
 
     steps:
-      - name: Checkout repository
+      - name: checkout
         uses: actions/checkout@v2
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Log-in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push container image
+        run: |
+          IMAGE_ID=$(echo ghcr.io/${{ github.repository }} | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # when the branch is main, replace main with latest
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          # Build and Publish container image
+          docker buildx build --push \
+          --tag $IMAGE_ID:$VERSION \
+          --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG BALENA_MACHINE_NAME_ARG=%%BALENA_MACHINE_NAME%%
-
-FROM balenalib/$BALENA_MACHINE_NAME_ARG-alpine:run
+FROM alpine:3.13.6
 
 RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add bash curl iptables tailscale jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.6
+FROM alpine:3.16
 
 RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add bash curl iptables tailscale jq

--- a/README.md
+++ b/README.md
@@ -16,15 +16,20 @@ volumes:
 
 services:
   tailscale:
-    image: ghcr.io/hslatman/tailscale-balena-block
+    image: bh.cr/hslatman/herman/tailscale-aarch64
     restart: always
     network_mode: host
+    environment:
+      - TAILSCALE_KEY: <YOUR_TAILSCALE_KEY>
+      - TAILSCALE_IP: <BOOLEAN>
     volumes:
       - tailscale-state:/tailscale
 ```
 
 You'll need to provide a valid `Auth Key` to the `tailscale` service in the `TAILSCALE_KEY` variable.
 An `Auth Key` can be created in the [Tailscale Dashboard](https://login.tailscale.com/admin/settings/authkeys).
+
+If `TAILSCALE_IP` is set to `true`, then the Tailscale IP address of the device will be visible in the balenaCloud dashboard.
 
 ## Tailscale
 
@@ -33,16 +38,16 @@ It uses [WireGuard](https://www.wireguard.com/) to tunnel traffic between hosts.
 
 ## (Potential) Improvements
 
-[x] Provide Docker image for the block
-[ ] Be smarter when TAILSCALE_KEY is not yet set in Balena
-[ ] Provide additional configuration options
-    [ ] subnet routing
-    [ ] ...
-[ ] Expose some tags in Tailscale?
-[ ] Expose some tags in Balena?
-[ ] Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
-[ ] Some easy way for checking that Tailscale tunnel works?
-[ ] A way to refresh/reauth tailscaled state on command?
+- [x] Provide Docker image for the block
+- [ ] Be smarter when TAILSCALE_KEY is not yet set in Balena
+- [ ] Provide additional configuration options
+  - [ ] subnet routing
+  - [ ] ...
+- [ ] Expose some tags in Tailscale?
+- [x] Expose some tags in Balena?
+- [ ] Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
+- [ ] Some easy way for checking that Tailscale tunnel works?
+- [ ] A way to refresh/reauth tailscaled state on command?
 
 ## Legal
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ It uses [WireGuard](https://www.wireguard.com/) to tunnel traffic between hosts.
 - [ ] Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
 - [ ] Some easy way for checking that Tailscale tunnel works?
 - [ ] A way to refresh/reauth tailscaled state on command?
+- [x] Deploy to multi-arch fleets with GitHub actions
 
 ## Legal
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ Use this as standalone with the button below:
 
 Or add the following service to your docker-compose.yml:
 
-TODO: add Docker image for deployment
+```dockerfile  
+volumes:
+  tailscale-state: {}
+
+services:
+  tailscale:
+    image: ghcr.io/hslatman/tailscale-balena-block
+    restart: always
+    network_mode: host
+    volumes:
+      - tailscale-state:/tailscale
+```
 
 You'll need to provide a valid `Auth Key` to the `tailscale` service in the `TAILSCALE_KEY` variable.
 An `Auth Key` can be created in the [Tailscale Dashboard](https://login.tailscale.com/admin/settings/authkeys).
@@ -22,17 +33,16 @@ It uses [WireGuard](https://www.wireguard.com/) to tunnel traffic between hosts.
 
 ## (Potential) Improvements
 
-* Provide Docker image for the block
-* Be smarter when TAILSCALE_KEY is not yet set in Balena
-* Provide additional configuration options
-    * subnet routing
-    * ...
-* Expose some tags in Tailscale?
-* Expose some tags in Balena?
-* Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
-* Some easy way for checking that Tailscale tunnel works?
-* A way to refresh/reauth tailscaled state on command?
-* ...
+[x] Provide Docker image for the block
+[ ] Be smarter when TAILSCALE_KEY is not yet set in Balena
+[ ] Provide additional configuration options
+    [ ] subnet routing
+    [ ] ...
+[ ] Expose some tags in Tailscale?
+[ ] Expose some tags in Balena?
+[ ] Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
+[ ] Some easy way for checking that Tailscale tunnel works?
+[ ] A way to refresh/reauth tailscaled state on command?
 
 ## Legal
 

--- a/balena.yml
+++ b/balena.yml
@@ -6,7 +6,7 @@ assets:
   repository:
     type: blob.asset
     data:
-      url: 'https://github.com/hslatman/tailscale-balena-block'
+      url: "https://github.com/hslatman/tailscale-balena-block"
   logo:
     type: blob.asset
     data:
@@ -14,6 +14,7 @@ assets:
 data:
   applicationEnvironmentVariables:
     - TAILSCALE_KEY: <YOUR_TAILSCALE_KEY>
+    - TAILSCALE_IP: false
   defaultDeviceType: raspberrypi3
   supportedDeviceTypes:
     - raspberry-pi2

--- a/balena.yml
+++ b/balena.yml
@@ -16,9 +16,8 @@ data:
     - TAILSCALE_KEY: <YOUR_TAILSCALE_KEY>
   defaultDeviceType: raspberrypi3
   supportedDeviceTypes:
-    #- raspberry-pi
-    #- raspberry-pi2
+    - raspberry-pi2
     - raspberrypi3
-    #- raspberrypi4-64
-    #- fincm3
-    #- intel-nuc
+    - raspberrypi4-64
+    - fincm3
+    - intel-nuc

--- a/init.sh
+++ b/init.sh
@@ -43,5 +43,27 @@ fi
 tailscaled --tun=userspace-networking -state=/tailscale/tailscaled.state &
 sleep 5
 tailscale up -authkey "${TAILSCALE_KEY}" -hostname "${TAILSCALE_HOSTNAME}" $@
+IP_ADDRESS=$(tailscale ip -4)
 
+DEVICE_ID=$(curl -X GET "https://api.balena-cloud.com/v5/device?\$filter=uuid%20eq%20'${BALENA_DEVICE_UUID}'&\$select=id" -H "Content-Type: application/json" -H "Authorization: Bearer ${BALENA_API_KEY}" -s | jq -r '.d | .[] | .id')
+
+curl -X POST \
+"https://api.balena-cloud.com/v6/device_tag?\$filter=device/uuid%20eq%20'${BALENA_DEVICE_UUID}'" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer ${BALENA_API_KEY}" \
+--data '{
+    "device": "'${DEVICE_ID}'",
+    "tag_key": "TAILSCALE_IP",
+    "value": "'${IP_ADDRESS}'"
+}' \
+-s
+
+curl -X PATCH \
+"https://api.balena-cloud.com/v6/device_tag?\$filter=device/uuid%20eq%20'${BALENA_DEVICE_UUID}'" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer ${BALENA_API_KEY}" \
+--data '{
+    "tag_key": "TAILSCALE_IP",
+    "value": "'${IP_ADDRESS}'"
+}'
 fg


### PR DESCRIPTION
Hi @hslatman 

I really enjoyed messing around with this block you created so I thought I'd make some suggestions for adding even more features!

This PR includes:

- GitHub Actions for publishing Docker images to the GitHub image register, upon merging into main branch
- A smaller Alpine base images for lighter download sizes
- An initial push tag to balenaCloud dashboard (this is WIP because I'm not sure if this is how we'd want to do it?)
- Support for ARMv7, ARM64 and x64/x86 devices

I added a plain Dockerfile as well as the Dockerfile.template for building the base block images but this still allows for users who want to deploy directly to balenaCloud to use the Dockerfile.template.

Let me know what you think about these changes!