### PR TITLE
Fix usage of ACL tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,19 @@ services:
     environment:
       - TAILSCALE_KEY: <YOUR_TAILSCALE_KEY>
       - TAILSCALE_IP: <BOOLEAN>
+      - TAILSCALE_TAGS: <CUSTOM_TAGS>
     volumes:
       - tailscale-state:/tailscale
 ```
 
 You'll need to provide a valid `Auth Key` to the `tailscale` service in the `TAILSCALE_KEY` variable.
 An `Auth Key` can be created in the [Tailscale Dashboard](https://login.tailscale.com/admin/settings/authkeys).
+Take note of the [properties](https://tailscale.com/kb/1085/auth-keys/) you specify when creating a new key,
+if you don't specify `Pre-authorized` you will have to manually login via the console.
 
 If `TAILSCALE_IP` is set to `true`, then the Tailscale IP address of the device will be visible in the balenaCloud dashboard.
+
+If `TAILSCALE_TAGS` is set, `--advertise-tags=${TAILSCALE_TAGS}` is passed. Make sure to [define the tags first](https://tailscale.com/kb/1068/acl-tags/#defining-a-tag).
 
 ## Tailscale
 
@@ -43,7 +48,6 @@ It uses [WireGuard](https://www.wireguard.com/) to tunnel traffic between hosts.
 - [ ] Provide additional configuration options
   - [ ] subnet routing
   - [ ] ...
-- [ ] Expose some tags in Tailscale?
 - [x] Expose some tags in Balena?
 - [ ] Support kernel networking (instead of just userspace; also see [hslatman/tailscale-balena-rpi](https://github.com/hslatman/tailscale-balena-rpi))
 - [ ] Some easy way for checking that Tailscale tunnel works?

--- a/init.sh
+++ b/init.sh
@@ -36,14 +36,8 @@ if [ -z "${TAILSCALE_HOSTNAME}" ]; then
     export TAILSCALE_HOSTNAME=${BALENA_DEVICE_NAME_AT_INIT}
 fi
 
-# if [ -z "${TAILSCALE_TAGS}" ]; then
-#     export TAILSCALE_TAGS="tag:docker,tag:balena"
-# fi
-
 tailscaled --tun=userspace-networking -state=/tailscale/tailscaled.state &
 while ! tailscale status --peers=false >/dev/null 2>&1; do sleep 1; done
-
-TAILSCALE_TAGS="${TAILSCALE_TAGS}${TAILSCALE_TAGS+,}balena_fleet_name:${BALENA_APP_NAME},balena_device_uuid:${BALENA_DEVICE_UUID},balena_device_type:${BALENA_DEVICE_TYPE},balena_os_version:${BALENA_HOST_OS_VERSION}"
 
 tailscale up \
 	--authkey "${TAILSCALE_KEY}" \


### PR DESCRIPTION
Recent updates to tailscale have introduced server-side validation of
passed tags. They now need to be defined and associated with an owner.
Since they are used for access control, it's not appropriate to use them
to pass information

Signed-off-by: Robert Günzler <r@gnzler.io>
